### PR TITLE
ci: add Claude PR test + cleanup workflows and support files

### DIFF
--- a/.claude/skills/test-review/SKILL.md
+++ b/.claude/skills/test-review/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: test-review
+description: QA-review a PR by driving the changed pages of the Order demo app in a real browser via Playwright MCP, then writing a screenshot-rich markdown report.
+---
+
+# test-review
+
+## When to use
+
+Invoked from CI by the `claude-pr-test` workflow on PRs labeled `test`.
+The caller has already warmed up the browser with
+`mcp__playwright__browser_navigate` and started recording with
+`mcp__playwright__browser_start_video`. You drive everything in between.
+
+## Inputs you can rely on
+
+- `BASE_URL` env var, e.g. `http://localhost:8080`
+- `/tmp/pr-diff.txt` — unified diff for this PR
+- `/tmp/pr-changed-files.txt` — newline-separated paths
+
+## Route map
+
+The Order app under `src/Order/` serves four HTML pages. Map changed
+files to routes:
+
+| Changed file                                | Route           |
+|---------------------------------------------|-----------------|
+| `src/Order/public/index.html`               | `/`             |
+| `src/Order/public/update-order.html`        | `/update-order` |
+| `src/Order/public/webhook.html`             | `/webhook`      |
+| `src/Order/public/xml-conversion.html`      | `/order-xml`    |
+| `src/Order/index.js`                        | all four        |
+
+If the diff touches `src/Order/index.js` alone, visit `/` only — the
+other routes serve static files unchanged by server edits.
+
+## Procedure
+
+1. Read `/tmp/pr-changed-files.txt`. Build the de-duplicated list of
+   routes to test using the table above. If the list is empty (PR only
+   touched workflow / docs), visit `/` as a smoke check.
+
+2. For each route, in order:
+   - `mcp__playwright__browser_navigate` with `url: "${BASE_URL}${route}"`
+   - `mcp__playwright__browser_snapshot` (records the a11y tree in the
+     trace; you don't need to read its output unless interacting)
+   - `mcp__playwright__browser_take_screenshot` with a zero-padded
+     filename like `01-update-order-initial.png`. Keep a running
+     counter across all routes so filenames stay globally ordered.
+
+3. Light smoke interaction for routes with forms (`/update-order`,
+   `/webhook`, `/order-xml`):
+   - Identify visible inputs from the snapshot.
+   - Fill safe placeholder values via `mcp__playwright__browser_fill_form`
+     (`apiUrl: "http://example.invalid/api"`,
+     `apiToken: "ci-placeholder-token"`, etc.).
+   - **Do NOT click any submit / load / save button.** The app proxies
+     to `qbiltrade.com`; we have no real token in CI and a submit would
+     either hang or post junk upstream.
+   - Take a follow-up screenshot showing the filled form.
+
+4. After each route, capture diagnostics:
+   - `mcp__playwright__browser_console_messages`
+   - `mcp__playwright__browser_network_requests`
+   - Note any `error`-level console entries and any local
+     (`localhost:8080`) responses with status >= 400.
+
+5. Write the report. Use `tee` from Bash:
+   ```bash
+   tee /tmp/test-review-report.md <<'MARKDOWN'
+   ...report body...
+   MARKDOWN
+   ```
+   Structure:
+   - First line: `**Status:** PASS` / `WARN` / `FAIL`
+     - FAIL = any local 5xx or uncaught console error
+     - WARN = console warnings or 4xx responses
+     - PASS = everything else
+   - One `## /route` section per visited route, with the screenshots
+     inlined as `![caption](01-update-order-initial.png)` (filename
+     only — the workflow rewrites these to absolute URLs).
+   - A `## Diagnostics` section per route listing any console errors
+     / failed local requests in fenced code blocks.
+   - A trailing `## Files reviewed` section echoing
+     `/tmp/pr-changed-files.txt`.
+
+## Constraints
+
+- **Do NOT** call `mcp__playwright__browser_start_video`,
+  `mcp__playwright__browser_stop_video`, or
+  `mcp__playwright__browser_close` — the top-level prompt owns those.
+- **Do NOT** submit any form. The app's only outbound calls go to
+  `qbiltrade.com`, which we cannot reach with a valid token in CI.
+- Screenshot filenames MUST be zero-padded (`01-`, `02-`, …) — the
+  workflow's `flatten()` in the github-script step preserves ordering
+  via filename sort.
+- Stay within the Bash allowlist granted by the workflow: `git diff`,
+  `git log`, `cat`, `echo`, `tee`, `mkdir`, `ls`, `find`. Do not try
+  `curl` / `node` / `npm` — they will be denied.

--- a/.github/actions/setup-app-server/action.yml
+++ b/.github/actions/setup-app-server/action.yml
@@ -1,0 +1,59 @@
+name: Setup App Server
+description: Install dependencies for src/Order and start it on http://localhost:8080 in the background.
+
+inputs:
+  github-token:
+    description: GitHub token (reserved for future authenticated installs).
+    required: false
+    default: ""
+  port:
+    description: Port to bind the Order app to.
+    required: false
+    default: "8080"
+
+outputs:
+  base_url:
+    description: URL the app is reachable at.
+    value: http://localhost:${{ inputs.port }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - name: Install Order app dependencies
+      shell: bash
+      working-directory: src/Order
+      run: npm install --no-audit --no-fund
+
+    - name: Start Order app in background
+      shell: bash
+      working-directory: src/Order
+      env:
+        PORT: ${{ inputs.port }}
+      run: |
+        set -euo pipefail
+        nohup node index.js > /tmp/app.log 2>&1 &
+        echo "APP_PID=$!" >> "${GITHUB_ENV}"
+        echo "Started node index.js, pid $!"
+
+    - name: Wait for app to be ready
+      shell: bash
+      env:
+        PORT: ${{ inputs.port }}
+      run: |
+        set -uo pipefail
+        for i in $(seq 1 30); do
+          if curl -fsS -o /dev/null "http://localhost:${PORT}/"; then
+            echo "App is up after ${i}s"
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "::error::App never became healthy on port ${PORT}"
+        echo "--- /tmp/app.log ---"
+        tail -100 /tmp/app.log || true
+        exit 1

--- a/.github/workflows/claude-pr-test-cleanup.yml
+++ b/.github/workflows/claude-pr-test-cleanup.yml
@@ -1,0 +1,65 @@
+name: Claude PR Test Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+concurrency:
+  group: claude-pr-test-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Remove screenshots for closed PR
+    if: contains(github.event.pull_request.labels.*.name, 'test')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+
+    steps:
+      - name: Remove pr-${{ env.PR_NUMBER }} from ci-screenshots branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+
+          git config --global user.email "claude-pr-test@users.noreply.github.com"
+          git config --global user.name "claude-pr-test"
+
+          SCRATCH=$(mktemp -d)
+          if ! git clone --branch ci-screenshots --single-branch --depth 1 \
+              "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+              "${SCRATCH}" 2>/dev/null; then
+            echo "ci-screenshots branch does not exist — nothing to clean"
+            exit 0
+          fi
+
+          cd "${SCRATCH}"
+          if [ ! -d "pr-${PR_NUMBER}" ]; then
+            echo "No screenshots for PR #${PR_NUMBER}"
+            exit 0
+          fi
+
+          git rm -rf "pr-${PR_NUMBER}"
+
+          if git diff --staged --quiet; then
+            echo "Nothing staged after git rm — already clean"
+            exit 0
+          fi
+
+          git commit -m "[skip ci] remove screenshots for closed PR #${PR_NUMBER}"
+
+          for attempt in 1 2; do
+            if git push origin ci-screenshots; then
+              echo "Pushed on attempt ${attempt}"
+              exit 0
+            fi
+            if [ "${attempt}" -eq 2 ]; then
+              echo "::error::Failed to push cleanup commit after rebase"
+              exit 1
+            fi
+            echo "Push rejected; pulling --rebase and retrying"
+            git pull --rebase origin ci-screenshots
+          done

--- a/.github/workflows/claude-pr-test.yml
+++ b/.github/workflows/claude-pr-test.yml
@@ -1,0 +1,353 @@
+name: Claude PR Test
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+    paths:
+      - src/**
+      - templates/**
+      - config/**
+      - assets/**
+      - migrations/**
+      - public/**
+      - e2e/**
+      - .claude/skills/test-review/**
+      - .github/workflows/claude-pr-test.yml
+      - .github/actions/setup-app-server/**
+
+concurrency:
+  group: claude-pr-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Claude test-review on PR
+    if: >-
+      github.event.pull_request.draft == false
+      && (
+        (github.event.action == 'labeled' && github.event.label.name == 'test')
+        || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'test'))
+      )
+    runs-on: ubuntu-latest-m
+    timeout-minutes: 25
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      RUN_ID: ${{ github.run_id }}
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+          show-progress: false
+
+      - name: Setup App Server
+        uses: ./.github/actions/setup-app-server
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Playwright Chromium
+        run: npx --yes playwright install --with-deps chromium
+
+      - name: Write PR diff for the skill
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh pr diff "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" > /tmp/pr-diff.txt
+          gh pr diff "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --name-only > /tmp/pr-changed-files.txt
+          if [ ! -s /tmp/pr-changed-files.txt ]; then
+            echo "Empty diff — gh pr diff produced no output. Aborting."
+            exit 1
+          fi
+          echo "Changed files:"
+          cat /tmp/pr-changed-files.txt
+
+      - name: Write Playwright MCP config and Claude settings
+        env:
+          PW_OUTPUT_DIR: ${{ github.workspace }}/pw-output
+        run: |
+          mkdir -p "${PW_OUTPUT_DIR}"
+
+          # MCP server config — consumed by `--mcp-config` flag
+          cat > /tmp/mcp-playwright.json <<JSON
+          {
+            "mcpServers": {
+              "playwright": {
+                "command": "npx",
+                "args": [
+                  "-y", "@playwright/mcp@latest",
+                  "--headless",
+                  "--browser", "chromium",
+                  "--caps", "devtools",
+                  "--isolated",
+                  "--viewport-size", "1920x1080",
+                  "--output-dir", "${PW_OUTPUT_DIR}",
+                  "--save-session"
+                ]
+              }
+            }
+          }
+          JSON
+
+          # Claude Code settings — consumed by the action's `settings:` input.
+          # Using a structured JSON file avoids the shell-tokenisation pitfalls
+          # of passing `--allowed-tools "Bash(foo bar)"` through claude_args.
+          cat > /tmp/claude-settings.json <<'JSON'
+          {
+            "permissions": {
+              "allow": [
+                "Read",
+                "Glob",
+                "Grep",
+                "Skill",
+                "Bash(git diff*)",
+                "Bash(git log*)",
+                "Bash(cat*)",
+                "Bash(echo*)",
+                "Bash(tee*)",
+                "Bash(mkdir*)",
+                "Bash(ls*)",
+                "Bash(find*)",
+                "mcp__playwright__browser_navigate",
+                "mcp__playwright__browser_take_screenshot",
+                "mcp__playwright__browser_click",
+                "mcp__playwright__browser_type",
+                "mcp__playwright__browser_fill_form",
+                "mcp__playwright__browser_select_option",
+                "mcp__playwright__browser_snapshot",
+                "mcp__playwright__browser_wait_for",
+                "mcp__playwright__browser_hover",
+                "mcp__playwright__browser_press_key",
+                "mcp__playwright__browser_evaluate",
+                "mcp__playwright__browser_console_messages",
+                "mcp__playwright__browser_network_requests",
+                "mcp__playwright__browser_mouse_click_xy",
+                "mcp__playwright__browser_close",
+                "mcp__playwright__browser_start_video",
+                "mcp__playwright__browser_stop_video",
+                "mcp__playwright__browser_start_tracing",
+                "mcp__playwright__browser_stop_tracing"
+              ]
+            }
+          }
+          JSON
+
+      - name: Run Claude test-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          settings: /tmp/claude-settings.json
+          claude_args: --mcp-config /tmp/mcp-playwright.json
+          prompt: |
+            You are running a QA review of a PR in CI. Execute this exact
+            sequence (the recording tools must be called by YOU at the top
+            level — not delegated to the skill, because the skill's own
+            allowed-tools list does not include them):
+
+            1. Call `mcp__playwright__browser_navigate` once with
+               `url: "http://localhost:8080/"` to warm up the browser
+               context. Then call `mcp__playwright__browser_start_video` with
+               no arguments to start recording.
+
+            2. Invoke the `test-review` skill via the Skill tool. The skill
+               is at `.claude/skills/test-review/SKILL.md`. It will detect CI
+               mode from the `BASE_URL` env var (already set to
+               `http://localhost:8080`) and read the diff from
+               `/tmp/pr-diff.txt` + `/tmp/pr-changed-files.txt`. The skill
+               will drive the browser, take screenshots with zero-padded
+               filenames (`01-...png`, `02-...png`, ...), and write its
+               report to `/tmp/test-review-report.md` using bash echo/tee.
+
+            3. After the skill returns (regardless of pass/fail), call
+               `mcp__playwright__browser_stop_video` to finalize the .webm,
+               then `mcp__playwright__browser_close` to release the browser.
+               Do this even if the skill reported failures — the recording
+               is the most diagnostic artifact.
+
+            If any of the MCP tool calls return "permission not granted",
+            stop immediately and write a one-line note to
+            `/tmp/test-review-report.md` saying which tool was denied —
+            that's the bug the workflow needs to fix.
+        env:
+          BASE_URL: http://localhost:8080
+          AWS_ACCESS_KEY_ID: x
+          AWS_SECRET_ACCESS_KEY: x
+          AWS_DEFAULT_REGION: eu-central-1
+
+      - name: Locate Playwright recording
+        if: always()
+        run: |
+          WEBM=$(find pw-output -name '*.webm' 2>/dev/null | head -1 || true)
+          if [ -n "${WEBM}" ]; then
+            mv "${WEBM}" pw-output/session.webm
+            echo "Renamed ${WEBM} -> pw-output/session.webm"
+          else
+            echo "No .webm produced by Playwright MCP"
+          fi
+
+      - name: Push screenshots and video to ci-screenshots branch
+        if: always()
+        id: push_media
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+
+          shopt -s nullglob
+          PNGS=(pw-output/*.png)
+          if [ ${#PNGS[@]} -eq 0 ] && [ ! -f pw-output/session.webm ]; then
+            echo "No media to push"
+            exit 0
+          fi
+
+          # Publish the media_base_url early so the comment step can use it
+          # even if the push itself fails partway.
+          DEST_REL="pr-${PR_NUMBER}/run-${RUN_ID}"
+          BASE="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/ci-screenshots/${DEST_REL}"
+          echo "media_base_url=${BASE}" >> "${GITHUB_OUTPUT}"
+
+          git config --global user.email "claude-pr-test@users.noreply.github.com"
+          git config --global user.name "claude-pr-test"
+
+          SCRATCH=$(mktemp -d)
+          if ! git clone --branch ci-screenshots --single-branch --depth 1 \
+              "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+              "${SCRATCH}" 2>/dev/null; then
+            echo "::warning::ci-screenshots branch does not exist on origin. Run the one-time bootstrap from the plan file before merging this workflow."
+            exit 0
+          fi
+
+          DEST="${SCRATCH}/${DEST_REL}"
+          rm -rf "${DEST}"
+          mkdir -p "${DEST}"
+
+          for f in "${PNGS[@]}"; do
+            cp "${f}" "${DEST}/"
+          done
+          if [ -f pw-output/session.webm ]; then
+            cp pw-output/session.webm "${DEST}/"
+          fi
+
+          cd "${SCRATCH}"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No staged changes"
+            exit 0
+          fi
+
+          git commit -m "[skip ci] screenshots for PR #${PR_NUMBER} run ${RUN_ID}"
+
+          # Retry once with rebase in case a concurrent run pushed first.
+          for attempt in 1 2; do
+            if git push origin ci-screenshots; then
+              echo "Pushed on attempt ${attempt}"
+              break
+            fi
+            if [ "${attempt}" -eq 2 ]; then
+              echo "::error::Failed to push to ci-screenshots after rebase. media_base_url may point to missing files."
+              exit 1
+            fi
+            echo "Push rejected; pulling --rebase and retrying"
+            git pull --rebase origin ci-screenshots
+          done
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-pr-test-${{ env.PR_NUMBER }}-${{ env.RUN_ID }}
+          path: |
+            pw-output/
+            /tmp/test-review-report.md
+            /tmp/pr-diff.txt
+            /tmp/pr-changed-files.txt
+            e2e/logs/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Post / update PR comment
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          MEDIA_BASE_URL: ${{ steps.push_media.outputs.media_base_url }}
+        with:
+          script: |
+            const fs = require('fs');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const runId = process.env.RUN_ID;
+            const mediaBase = process.env.MEDIA_BASE_URL || '';
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${runId}`;
+
+            if (!Number.isFinite(prNumber)) {
+              core.setFailed(`PR_NUMBER env var is invalid: "${process.env.PR_NUMBER}"`);
+              return;
+            }
+
+            const reportPath = '/tmp/test-review-report.md';
+            let report = fs.existsSync(reportPath)
+              ? fs.readFileSync(reportPath, 'utf8').trim()
+              : '_No report produced — see workflow logs._';
+
+            // Rewrite relative image refs (both markdown and HTML) → orphan-branch URLs.
+            // Strip any query string / fragment via URL parsing; flatten subdirs.
+            const stripQuery = (p) => p.split(/[?#]/)[0];
+            const flatten = (p) => stripQuery(p).split('/').pop();
+
+            if (mediaBase) {
+              // Markdown form: ![alt](relative.png)
+              report = report.replace(
+                /!\[((?:\\.|[^\]])*)\]\(((?!https?:|data:)[^)\s]+?\.(?:png|jpg|jpeg|gif|webp))(?:\s+"[^"]*")?\)/gi,
+                (_, alt, file) => `![${alt}](${mediaBase}/${flatten(file)})`
+              );
+              // HTML form: <img src="relative.png" …>
+              report = report.replace(
+                /<img\b([^>]*?)\bsrc=(["'])((?!https?:|data:)[^"']+?\.(?:png|jpg|jpeg|gif|webp))\2/gi,
+                (_, pre, q, file) => `<img${pre}src=${q}${mediaBase}/${flatten(file)}${q}`
+              );
+            }
+
+            const marker = '<!-- claude-pr-test-comment -->';
+            const footerParts = [`[Trace artifact](${runUrl})`];
+            if (mediaBase) {
+              footerParts.unshift(`📹 [Watch session](${mediaBase}/session.webm)`);
+            }
+
+            const header = `### 🔍 Test Review — pr-${prNumber} · run #${runId}`;
+            const footer = `---\n${footerParts.join(' · ')}`;
+            // GitHub comment hard-limit is 65,536 chars. Stay under with headroom.
+            const MAX_BODY = 60000;
+            const overhead = `${marker}\n${header}\n\n\n\n${footer}`.length;
+            const truncationNote = '\n\n_…report truncated — see the artifact for the full version._';
+            let safeReport = report;
+            if (overhead + safeReport.length > MAX_BODY) {
+              const allowed = MAX_BODY - overhead - truncationNote.length;
+              safeReport = safeReport.slice(0, Math.max(0, allowed)) + truncationNote;
+            }
+
+            const body = [marker, header, '', safeReport, '', footer].join('\n');
+
+            // Paginate listComments — default page size is 30; long-running PRs exceed it.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: prNumber, body,
+              });
+            }

--- a/src/Order/UPDATE_ORDER_README.md
+++ b/src/Order/UPDATE_ORDER_README.md
@@ -1,0 +1,113 @@
+# Update Order API Demo
+
+A simple web application to demonstrate updating order fields using the QBil Trade API.
+
+## Features
+
+- 🔐 API Configuration with Bearer Token authentication
+- 📥 Load existing order data
+- ✏️ Update order fields (delivery mode, dates, notes, etc.)
+- 📋 View API responses in formatted JSON
+- 💾 Persistent configuration storage
+- 🎨 Modern, responsive UI matching existing apps
+
+## Getting Started
+
+1. Navigate to the Order directory:
+   ```bash
+   cd /home/sadiq/Desktop/api-demo-apps/src/Order
+   ```
+
+2. Install dependencies (if not already installed):
+   ```bash
+   npm install
+   # or
+   yarn install
+   ```
+
+3. Start the server:
+   ```bash
+   node index.js
+   ```
+
+4. Open your browser and navigate to:
+   ```
+   http://localhost:3000/update-order
+   ```
+
+## How to Use
+
+### 1. Configure API Settings
+- Enter your API Base URL (e.g., `https://demo.qbiltrade.com/api/v1/orders`)
+- Enter your Bearer Token
+- Click "Save Config" to persist settings
+
+### 2. Load an Order (Optional)
+- Enter an Order ID
+- Click "Load Order" to fetch and populate the form with existing data
+
+### 3. Update Order Fields
+- Fill in the fields you want to update:
+  - Order Numbering Type
+  - Delivery Mode (Pallet, Container, Truck, Bulk)
+  - BL Number
+  - Notes
+  - Transporter Booking Number
+  - License Plate
+  - Intra Communicator
+  - Various dates (Arrival, Departure, BL, Loading, Unloading)
+- Click "Update Order" to send the PATCH request
+- View the API response in the response panel
+
+### 4. Additional Actions
+- **Clear Form**: Reset all form fields
+- **Copy Response**: Copy the API response to clipboard
+- **Clear Response**: Hide the response panel
+- **Home**: Return to the main dashboard
+
+## API Endpoint
+
+The app uses the following API endpoint:
+
+```
+PATCH https://demo.qbiltrade.com/api/v1/orders/:id
+```
+
+### Headers
+- `Content-Type: application/merge-patch+json`
+- `Accept: application/json`
+- `Authorization: Bearer <API User Token>`
+
+### Request Body
+The app only sends fields that have values, following the merge-patch pattern.
+
+## UI Features
+
+- **Responsive Design**: Works on desktop, tablet, and mobile
+- **Loading Indicators**: Visual feedback during API calls
+- **Status Messages**: Success/error notifications with auto-dismiss
+- **JSON Formatting**: Pretty-printed API responses
+- **Persistent Config**: Saves API settings in browser localStorage
+
+## Technical Details
+
+- **Framework**: Vanilla JavaScript (no dependencies in frontend)
+- **Backend**: Fastify server serving static files
+- **CSS**: Custom styling matching existing app theme
+- **HTTP Method**: PATCH with `application/merge-patch+json`
+
+## Notes
+
+- Only non-empty fields are sent in the update request
+- The app supports partial updates (you don't need to fill all fields)
+- Configuration is stored in browser localStorage for convenience
+- The response panel shows the complete API response for debugging
+
+## Integration with Other Apps
+
+This app is part of the API Sample Apps suite:
+- **Fetching Orders and Download Documents** (`/order-xml`)
+- **Data syncing with Webhook** (`/webhook`)
+- **Updating Orders** (`/update-order`) ← You are here
+
+Access all apps from the main dashboard at `http://localhost:3000/`

--- a/src/Order/index.js
+++ b/src/Order/index.js
@@ -111,8 +111,9 @@ fastify.get('/get-data', async (req, reply) => {
 // Start server
 const start = async () => {
     try {
-        await fastify.listen({ port: 3000, host: '0.0.0.0' });
-        console.log('🚀 Server running at http://localhost:3000');
+        const port = Number(process.env.PORT) || 3000;
+        await fastify.listen({ port, host: '0.0.0.0' });
+        console.log(`🚀 Server running at http://localhost:${port}`);
     } catch (err) {
         fastify.log.error(err);
         process.exit(1);

--- a/src/Order/public/update-order.html
+++ b/src/Order/public/update-order.html
@@ -1,0 +1,1036 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Update Order - API Demo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script
+            src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/js/all.min.js"
+            defer
+    ></script>
+</head>
+<body
+        class="min-h-screen bg-gradient-to-br from-[#1d394b] to-[#2e8555] font-sans text-gray-900"
+>
+<!-- Loader -->
+<div
+        id="loader"
+        class="hidden fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+>
+    <div
+            class="w-12 h-12 border-4 border-white border-t-transparent rounded-full animate-spin"
+    ></div>
+</div>
+
+<div class="max-w-7xl mx-auto p-6">
+    <!-- Header -->
+    <header class="text-center mb-8 relative">
+        <h1
+                class="text-4xl md:text-5xl font-bold text-white drop-shadow-lg flex justify-center items-center gap-2"
+        >
+            <i class="fas fa-edit"></i> Update Order
+        </h1>
+        <p class="text-white/80 mt-2">
+            Modify and update order information
+        </p>
+        <div class="mt-4">
+            <a
+                    href="https://developers.qbiltrade.com"
+                    class="inline-block px-4 py-2 rounded-full border border-white/40 bg-white/20 text-white backdrop-blur-md hover:bg-white/30 shadow transition"
+            >
+                🏠 Back to Home
+            </a>
+        </div>
+    </header>
+
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <!-- Left Panel -->
+        <div class="lg:col-span-1 space-y-6">
+            <!-- API Configuration -->
+            <div
+                    class="bg-white/95 rounded-xl shadow p-6 hover:shadow-2xl transition"
+            >
+                <h3
+                        class="text-xl font-semibold flex items-center gap-2 mb-4"
+                >
+                    <i class="fas fa-cog"></i> API Configuration
+                </h3>
+                <form class="space-y-4">
+                    <div>
+                        <label
+                                for="apiUrl"
+                                class="block text-sm font-medium text-gray-700"
+                        >API Base URL</label
+                        >
+                        <input
+                                type="text"
+                                id="apiUrl"
+                                placeholder="https://demo.qbiltrade.com/api/v1/orders"
+                                value="https://demo.qbiltrade.com/api/v1/orders"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        />
+                    </div>
+                    <div>
+                        <label
+                                for="apiToken"
+                                class="block text-sm font-medium text-gray-700"
+                        >Bearer Token</label
+                        >
+                        <input
+                                type="password"
+                                id="apiToken"
+                                placeholder="Enter your API token"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        />
+                    </div>
+                    <button
+                            type="button"
+                            onclick="saveConfig()"
+                            class="w-full bg-[#2e8555] hover:bg-[#29784c] text-white px-4 py-2 rounded-lg font-semibold transition"
+                    >
+                        <i class="fas fa-save"></i> Save Configuration
+                    </button>
+                </form>
+                <div id="configStatus" class="mt-4"></div>
+            </div>
+
+            <!-- Order Selection -->
+            <div
+                    class="bg-white/95 rounded-xl shadow p-6 hover:shadow-2xl transition"
+            >
+                <h3
+                        class="text-xl font-semibold flex items-center gap-2 mb-4"
+                >
+                    <i class="fas fa-search"></i> Select Order
+                </h3>
+                <div class="space-y-4">
+                    <div>
+                        <label
+                                for="orderId"
+                                class="block text-sm font-medium text-gray-700"
+                        >Order ID</label
+                        >
+                        <input
+                                type="text"
+                                id="orderId"
+                                placeholder="Enter Order ID"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        />
+                    </div>
+                    <button
+                            onclick="loadOrder()"
+                            class="w-full bg-[#2e8555] hover:bg-[#29784c] text-white px-4 py-2 rounded-lg font-semibold transition"
+                    >
+                        <i class="fas fa-download"></i> Load Order
+                    </button>
+                </div>
+                <div id="loadStatus" class="mt-4"></div>
+            </div>
+        </div>
+
+        <!-- Right Panel -->
+        <div class="lg:col-span-2 space-y-6">
+            <!-- Update Form -->
+            <div
+                    class="bg-white/95 rounded-xl shadow p-6 hover:shadow-2xl transition"
+            >
+                <h3
+                        class="text-xl font-semibold flex items-center gap-2 mb-4"
+                >
+                    <i class="fas fa-edit"></i> Update Order Fields
+                </h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <label
+                                for="orderNumberingType"
+                                class="block text-sm font-medium text-gray-700"
+                        >Order Numbering Type</label
+                        >
+                        <input
+                                type="text"
+                                id="orderNumberingType"
+                                placeholder="e.g., AUTO, MANUAL"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        />
+                    </div>
+
+                    <div>
+                        <label
+                                for="orderDeliveryMode"
+                                class="block text-sm font-medium text-gray-700"
+                        >Delivery Mode</label
+                        >
+                        <select
+                                id="orderDeliveryMode"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        >
+                            <option value="">-- Select --</option>
+                            <option value="Pallet">Pallet</option>
+                            <option value="Container">Container</option>
+                            <option value="Truck">Truck</option>
+                            <option value="Bulk">Bulk</option>
+                        </select>
+                    </div>
+
+                    <div>
+                        <label
+                                for="blNumber"
+                                class="block text-sm font-medium text-gray-700"
+                        >BL Number</label
+                        >
+                        <input
+                                type="text"
+                                id="blNumber"
+                                placeholder="e.g., BL-67890"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        />
+                    </div>
+
+                    <div>
+                        <label
+                                for="notes"
+                                class="block text-sm font-medium text-gray-700"
+                        >Notes</label
+                        >
+                        <input
+                                type="text"
+                                id="notes"
+                                placeholder="Some notes about the order"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        />
+                    </div>
+
+                    <div>
+                        <label
+                                for="transporterBookingNo"
+                                class="block text-sm font-medium text-gray-700"
+                        >Transporter Booking No</label
+                        >
+                        <input
+                                type="text"
+                                id="transporterBookingNo"
+                                placeholder="e.g., TB-123456"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        />
+                    </div>
+
+                    <div>
+                        <label
+                                for="licensePlate"
+                                class="block text-sm font-medium text-gray-700"
+                        >License Plate</label
+                        >
+                        <input
+                                type="text"
+                                id="licensePlate"
+                                placeholder="e.g., ABC-1234"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        />
+                    </div>
+
+                    <div>
+                        <label
+                                for="intraCommunicator"
+                                class="block text-sm font-medium text-gray-700"
+                        >Intra Communicator</label
+                        >
+                        <select
+                                id="intraCommunicator"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        >
+                            <option value="">-- Select --</option>
+                            <option value="Unknown">Unknown</option>
+                            <option value="Yes">Yes</option>
+                            <option value="No">No</option>
+                        </select>
+                    </div>
+
+                    <div>
+                        <label
+                                for="arrivalDate"
+                                class="block text-sm font-medium text-gray-700"
+                        >Arrival Date</label
+                        >
+                        <input
+                                type="date"
+                                id="arrivalDate"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        />
+                    </div>
+
+                    <div>
+                        <label
+                                for="departureDate"
+                                class="block text-sm font-medium text-gray-700"
+                        >Departure Date</label
+                        >
+                        <input
+                                type="date"
+                                id="departureDate"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        />
+                    </div>
+
+                    <div>
+                        <label
+                                for="blDate"
+                                class="block text-sm font-medium text-gray-700"
+                        >BL Date</label
+                        >
+                        <input
+                                type="date"
+                                id="blDate"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        />
+                    </div>
+
+                    <div>
+                        <label
+                                for="loadingDate"
+                                class="block text-sm font-medium text-gray-700"
+                        >Loading Date</label
+                        >
+                        <input
+                                type="date"
+                                id="loadingDate"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        />
+                    </div>
+
+                    <div>
+                        <label
+                                for="unloadingDate"
+                                class="block text-sm font-medium text-gray-700"
+                        >Unloading Date</label
+                        >
+                        <input
+                                type="date"
+                                id="unloadingDate"
+                                class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        />
+                    </div>
+                </div>
+
+                <div class="flex gap-3 mt-6">
+                    <button
+                            onclick="updateOrder()"
+                            class="bg-[#2e8555] hover:bg-[#29784c] text-white px-4 py-2 rounded-lg text-sm font-semibold transition"
+                    >
+                        <i class="fas fa-sync-alt"></i> Update Order
+                    </button>
+                    <button
+                            onclick="clearForm()"
+                            class="bg-[#466275] hover:bg-[#3a5060] text-white px-4 py-2 rounded-lg text-sm font-semibold transition"
+                    >
+                        <i class="fas fa-trash"></i> Clear Form
+                    </button>
+                </div>
+
+                <div id="updateStatus" class="mt-4"></div>
+            </div>
+
+            <!-- Order Lines Section -->
+            <div
+                    id="orderLinesSection"
+                    class="hidden bg-white/95 rounded-xl shadow p-6 hover:shadow-2xl transition"
+            >
+                <h3
+                        class="text-xl font-semibold flex items-center gap-2 mb-4"
+                >
+                    <i class="fas fa-list"></i> Update Order Lines
+                </h3>
+
+                <!-- Order Line Selection -->
+                <div class="mb-4">
+                    <label
+                            for="orderLineType"
+                            class="block text-sm font-medium text-gray-700 mb-2"
+                    >Select Order Line Type</label
+                    >
+                    <div class="flex gap-2">
+                        <select
+                                id="orderLineType"
+                                class="flex-1 rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                        >
+                            <option value="">
+                                -- Select Line Type --
+                            </option>
+                            <option value="purchase">
+                                Purchase Lines
+                            </option>
+                            <option value="sales">Sales Lines</option>
+                            <option value="stock">Stock Lines</option>
+                        </select>
+                        <button
+                                onclick="fetchOrderLines()"
+                                class="bg-[#2e8555] hover:bg-[#29784c] text-white px-4 py-2 rounded-lg text-sm font-semibold transition"
+                        >
+                            <i class="fas fa-download"></i> Fetch Lines
+                        </button>
+                    </div>
+                </div>
+
+                <!-- Order Line Update Form -->
+                <div id="orderLineForm" class="hidden">
+                    <div class="border-t border-gray-200 pt-4 mt-4">
+                        <label
+                                for="lineSelect"
+                                class="block text-sm font-medium text-gray-700 mb-2"
+                        >Select Line to Update</label
+                        >
+                        <select
+                                id="lineSelect"
+                                onchange="loadLineData()"
+                                class="w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm mb-4"
+                        >
+                            <option value="">
+                                -- Select a line --
+                            </option>
+                        </select>
+
+                        <div
+                                id="lineFieldsContainer"
+                                class="hidden grid grid-cols-1 md:grid-cols-2 gap-4 mb-4"
+                        >
+                            <div>
+                                <label
+                                        for="lineQuantity"
+                                        class="block text-sm font-medium text-gray-700"
+                                >Quantity</label
+                                >
+                                <input
+                                        type="number"
+                                        id="lineQuantity"
+                                        step="0.01"
+                                        placeholder="e.g., 100"
+                                        class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                                />
+                            </div>
+                            <div>
+                                <label
+                                        for="linePrice"
+                                        class="block text-sm font-medium text-gray-700"
+                                >Price</label
+                                >
+                                <input
+                                        type="number"
+                                        id="linePrice"
+                                        step="0.01"
+                                        placeholder="e.g., 99.99"
+                                        class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                                />
+                            </div>
+                            <div>
+                                <label
+                                        for="lineDescription"
+                                        class="block text-sm font-medium text-gray-700"
+                                >Description</label
+                                >
+                                <input
+                                        type="text"
+                                        id="lineDescription"
+                                        placeholder="Line description"
+                                        class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                                />
+                            </div>
+                            <div>
+                                <label
+                                        for="lineStatus"
+                                        class="block text-sm font-medium text-gray-700"
+                                >Status</label
+                                >
+                                <input
+                                        type="text"
+                                        id="lineStatus"
+                                        placeholder="e.g., Pending, Confirmed"
+                                        class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:ring-[#2e8555] focus:border-[#2e8555] p-2 text-sm"
+                                />
+                            </div>
+                        </div>
+
+                        <button
+                                onclick="updateOrderLine()"
+                                class="w-full bg-[#2e8555] hover:bg-[#29784c] text-white px-3 py-2 rounded-lg text-sm font-semibold transition hidden"
+                                id="updateLineBtn"
+                        >
+                            <i class="fas fa-save"></i> Update Order
+                            Line
+                        </button>
+                    </div>
+                </div>
+
+                <div id="lineStatus" class="mt-4"></div>
+            </div>
+
+            <!-- Response Display -->
+            <div
+                    id="responseContainer"
+                    class="hidden bg-white/95 rounded-xl shadow p-6 hover:shadow-2xl transition"
+            >
+                <div class="flex justify-between items-center mb-4">
+                            <span
+                                    class="text-lg font-semibold flex items-center gap-2"
+                            >
+                                <i class="fas fa-code"></i> API Response
+                            </span>
+                    <div class="flex gap-2">
+                        <button
+                                onclick="copyResponse()"
+                                class="bg-[#2e8555] hover:bg-[#29784c] text-white px-3 py-1 rounded-lg text-sm transition"
+                        >
+                            <i class="fas fa-copy"></i> Copy
+                        </button>
+                        <button
+                                onclick="clearResponse()"
+                                class="bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded-lg text-sm transition"
+                        >
+                            <i class="fas fa-times"></i> Clear
+                        </button>
+                    </div>
+                </div>
+                <pre
+                        id="responseDisplay"
+                        class="bg-gray-100 rounded-lg p-4 text-sm overflow-x-auto whitespace-pre-wrap max-h-96"
+                ></pre>
+            </div>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer
+            class="text-center mt-12 p-6 bg-white/10 rounded-xl backdrop-blur-md"
+    >
+        <p class="text-white text-sm">&copy; 2026 API Sample Apps</p>
+    </footer>
+</div>
+
+<script>
+    let apiConfig = {
+        apiUrl: "",
+        apiToken: "",
+    };
+
+    // Load saved config from localStorage
+    window.onload = function () {
+        const saved = localStorage.getItem("apiConfig");
+        if (saved) {
+            apiConfig = JSON.parse(saved);
+            document.getElementById("apiUrl").value =
+                apiConfig.apiUrl ||
+                "https://demo.qbiltrade.com/api/v1/orders";
+            document.getElementById("apiToken").value =
+                apiConfig.apiToken || "";
+        }
+    };
+
+    function saveConfig() {
+        const apiUrl = document.getElementById("apiUrl").value.trim();
+        const apiToken = document
+            .getElementById("apiToken")
+            .value.trim();
+
+        if (!apiUrl || !apiToken) {
+            showStatus(
+                "configStatus",
+                "error",
+                "❌ Both API URL and Token are required!",
+            );
+            return;
+        }
+
+        apiConfig = { apiUrl, apiToken };
+        localStorage.setItem("apiConfig", JSON.stringify(apiConfig));
+        showStatus(
+            "configStatus",
+            "success",
+            "✅ Configuration saved successfully!",
+        );
+    }
+
+    async function loadOrder() {
+        const orderId = document.getElementById("orderId").value.trim();
+
+        if (!orderId) {
+            showStatus(
+                "loadStatus",
+                "error",
+                "❌ Please enter an Order ID",
+            );
+            return;
+        }
+
+        if (!apiConfig.apiUrl || !apiConfig.apiToken) {
+            showStatus(
+                "loadStatus",
+                "error",
+                "❌ Please configure API settings first",
+            );
+            return;
+        }
+
+        showLoader(true);
+
+        try {
+            const response = await fetch(
+                `${apiConfig.apiUrl}/${orderId}`,
+                {
+                    method: "GET",
+                    headers: {
+                        Authorization: `Bearer ${apiConfig.apiToken}`,
+                        Accept: "application/json",
+                    },
+                },
+            );
+
+            showLoader(false);
+
+            if (!response.ok) {
+                throw new Error(
+                    `HTTP ${response.status}: ${response.statusText}`,
+                );
+            }
+
+            const data = await response.json();
+            populateForm(data);
+            showStatus(
+                "loadStatus",
+                "success",
+                "✅ Order loaded successfully!",
+            );
+            displayResponse(data);
+
+            // Show order lines section if order has lines
+            if (data.lines && data.lines.length > 0) {
+                document
+                    .getElementById("orderLinesSection")
+                    .classList.remove("hidden");
+            }
+        } catch (error) {
+            showLoader(false);
+            showStatus(
+                "loadStatus",
+                "error",
+                `❌ Error: ${error.message}`,
+            );
+        }
+    }
+
+    function populateForm(data) {
+        document.getElementById("orderNumberingType").value =
+            data.orderNumberingType || "";
+        document.getElementById("orderDeliveryMode").value =
+            data.orderDeliveryMode || "";
+        document.getElementById("blNumber").value = data.blNumber || "";
+        document.getElementById("notes").value = data.notes || "";
+        document.getElementById("transporterBookingNo").value =
+            data.transporterBookingNo || "";
+        document.getElementById("licensePlate").value =
+            data.licensePlate || "";
+        document.getElementById("intraCommunicator").value =
+            data.intraCommunicator || "";
+        document.getElementById("arrivalDate").value =
+            data.arrivalDate || "";
+        document.getElementById("departureDate").value =
+            data.departureDate || "";
+        document.getElementById("blDate").value = data.blDate || "";
+        document.getElementById("loadingDate").value =
+            data.loadingDate || "";
+        document.getElementById("unloadingDate").value =
+            data.unloadingDate || "";
+    }
+
+    async function updateOrder() {
+        const orderId = document.getElementById("orderId").value.trim();
+
+        if (!orderId) {
+            showStatus(
+                "updateStatus",
+                "error",
+                "❌ Please enter an Order ID",
+            );
+            return;
+        }
+
+        if (!apiConfig.apiUrl || !apiConfig.apiToken) {
+            showStatus(
+                "updateStatus",
+                "error",
+                "❌ Please configure API settings first",
+            );
+            return;
+        }
+
+        // Build update payload with only non-empty fields
+        const payload = {};
+
+        const fields = [
+            "orderNumberingType",
+            "orderDeliveryMode",
+            "blNumber",
+            "notes",
+            "transporterBookingNo",
+            "licensePlate",
+            "intraCommunicator",
+            "arrivalDate",
+            "departureDate",
+            "blDate",
+            "loadingDate",
+            "unloadingDate",
+        ];
+
+        fields.forEach((field) => {
+            const value = document.getElementById(field).value.trim();
+            if (value) {
+                payload[field] = value;
+            }
+        });
+
+        if (Object.keys(payload).length === 0) {
+            showStatus(
+                "updateStatus",
+                "error",
+                "❌ Please fill at least one field to update",
+            );
+            return;
+        }
+
+        showLoader(true);
+
+        try {
+            const response = await fetch(
+                `${apiConfig.apiUrl}/${orderId}`,
+                {
+                    method: "PATCH",
+                    headers: {
+                        "Content-Type": "application/merge-patch+json",
+                        Accept: "application/json",
+                        Authorization: `Bearer ${apiConfig.apiToken}`,
+                    },
+                    body: JSON.stringify(payload),
+                },
+            );
+
+            showLoader(false);
+
+            const responseData = await response.json();
+
+            if (!response.ok) {
+                throw new Error(
+                    `HTTP ${response.status}: ${responseData.message || response.statusText}`,
+                );
+            }
+
+            showStatus(
+                "updateStatus",
+                "success",
+                "✅ Order updated successfully!",
+            );
+            displayResponse(responseData);
+        } catch (error) {
+            showLoader(false);
+            showStatus(
+                "updateStatus",
+                "error",
+                `❌ Error: ${error.message}`,
+            );
+        }
+    }
+
+    function clearForm() {
+        const fields = [
+            "orderNumberingType",
+            "orderDeliveryMode",
+            "blNumber",
+            "notes",
+            "transporterBookingNo",
+            "licensePlate",
+            "intraCommunicator",
+            "arrivalDate",
+            "departureDate",
+            "blDate",
+            "loadingDate",
+            "unloadingDate",
+        ];
+        fields.forEach((field) => {
+            document.getElementById(field).value = "";
+        });
+        showStatus("updateStatus", "success", "✅ Form cleared");
+    }
+
+    function displayResponse(data) {
+        const container = document.getElementById("responseContainer");
+        const display = document.getElementById("responseDisplay");
+        display.textContent = JSON.stringify(data, null, 2);
+        container.classList.remove("hidden");
+    }
+
+    function clearResponse() {
+        document
+            .getElementById("responseContainer")
+            .classList.add("hidden");
+        document.getElementById("responseDisplay").textContent = "";
+    }
+
+    function copyResponse() {
+        const text =
+            document.getElementById("responseDisplay").textContent;
+        navigator.clipboard.writeText(text).then(() => {
+            alert("✅ Response copied to clipboard!");
+        });
+    }
+
+    function showStatus(elementId, type, message) {
+        const statusEl = document.getElementById(elementId);
+        const bgColor =
+            type === "success"
+                ? "bg-[#e6f4ea] text-[#2e8555]"
+                : "bg-red-100 text-red-600";
+        const icon =
+            type === "success"
+                ? "fa-check-circle"
+                : "fa-exclamation-triangle";
+
+        statusEl.className = `p-4 rounded ${bgColor} flex items-center gap-2 mt-2`;
+        statusEl.innerHTML = `<i class="fas ${icon}"></i> ${message}`;
+
+        setTimeout(() => {
+            statusEl.innerHTML = "";
+            statusEl.className = "";
+        }, 5000);
+    }
+
+    function showLoader(show) {
+        document
+            .getElementById("loader")
+            .classList.toggle("hidden", !show);
+    }
+
+    // Order Line Management
+    let currentOrderLines = [];
+    let currentLineType = "";
+
+    async function fetchOrderLines() {
+        const orderId = document.getElementById("orderId").value.trim();
+        const lineType = document.getElementById("orderLineType").value;
+
+        if (!orderId) {
+            showStatus(
+                "lineStatus",
+                "error",
+                "❌ Please load an order first",
+            );
+            return;
+        }
+
+        if (!lineType) {
+            showStatus(
+                "lineStatus",
+                "error",
+                "❌ Please select a line type",
+            );
+            return;
+        }
+
+        if (!apiConfig.apiUrl || !apiConfig.apiToken) {
+            showStatus(
+                "lineStatus",
+                "error",
+                "❌ Please configure API settings first",
+            );
+            return;
+        }
+
+        showLoader(true);
+        currentLineType = lineType;
+
+        try {
+            const response = await fetch(
+                `${apiConfig.apiUrl}/${orderId}/${lineType}`,
+                {
+                    method: "GET",
+                    headers: {
+                        Authorization: `Bearer ${apiConfig.apiToken}`,
+                        Accept: "application/json",
+                    },
+                },
+            );
+
+            showLoader(false);
+
+            if (!response.ok) {
+                throw new Error(
+                    `HTTP ${response.status}: ${response.statusText}`,
+                );
+            }
+
+            const data = await response.json();
+            currentOrderLines = Array.isArray(data) ? data : [data];
+
+            populateLineSelect();
+            showStatus(
+                "lineStatus",
+                "success",
+                `✅ Fetched ${currentOrderLines.length} ${lineType} line(s)`,
+            );
+            displayResponse(data);
+        } catch (error) {
+            showLoader(false);
+            showStatus(
+                "lineStatus",
+                "error",
+                `❌ Error: ${error.message}`,
+            );
+        }
+    }
+
+    function populateLineSelect() {
+        const lineSelect = document.getElementById("lineSelect");
+        const orderLineForm = document.getElementById("orderLineForm");
+
+        if (currentOrderLines.length === 0) {
+            lineSelect.innerHTML =
+                '<option value="">-- No lines found --</option>';
+            orderLineForm.classList.add("hidden");
+            return;
+        }
+
+        lineSelect.innerHTML =
+            '<option value="">-- Select a line --</option>';
+        currentOrderLines.forEach((line, index) => {
+            const label =
+                line.id ||
+                line.lineNumber ||
+                line.displayNumber ||
+                `Line ${index + 1}`;
+            lineSelect.innerHTML += `<option value="${index}">${label}</option>`;
+        });
+
+        orderLineForm.classList.remove("hidden");
+    }
+
+    function loadLineData() {
+        const lineSelect = document.getElementById("lineSelect");
+        const selectedIndex = lineSelect.value;
+        const fieldsContainer = document.getElementById(
+            "lineFieldsContainer",
+        );
+        const updateBtn = document.getElementById("updateLineBtn");
+
+        if (selectedIndex === "") {
+            fieldsContainer.classList.add("hidden");
+            updateBtn.classList.add("hidden");
+            return;
+        }
+
+        const line = currentOrderLines[parseInt(selectedIndex)];
+
+        document.getElementById("lineQuantity").value =
+            line.quantity || "";
+        document.getElementById("linePrice").value =
+            line.price || line.unitPrice || "";
+        document.getElementById("lineDescription").value =
+            line.description || "";
+        document.getElementById("lineStatus").value = line.status || "";
+
+        fieldsContainer.classList.remove("hidden");
+        updateBtn.classList.remove("hidden");
+    }
+
+    async function updateOrderLine() {
+        const orderId = document.getElementById("orderId").value.trim();
+        const lineSelect = document.getElementById("lineSelect");
+        const selectedIndex = lineSelect.value;
+
+        if (selectedIndex === "") {
+            showStatus(
+                "lineStatus",
+                "error",
+                "❌ Please select a line to update",
+            );
+            return;
+        }
+
+        const line = currentOrderLines[parseInt(selectedIndex)];
+        const lineId = line.id;
+
+        if (!lineId) {
+            showStatus("lineStatus", "error", "❌ Line ID not found");
+            return;
+        }
+
+        const payload = {};
+
+        const quantity = document
+            .getElementById("lineQuantity")
+            .value.trim();
+        const price = document.getElementById("linePrice").value.trim();
+        const description = document
+            .getElementById("lineDescription")
+            .value.trim();
+        const status = document
+            .getElementById("lineStatus")
+            .value.trim();
+
+        if (quantity) payload.quantity = parseFloat(quantity);
+        if (price) payload.price = parseFloat(price);
+        if (description) payload.description = description;
+        if (status) payload.status = status;
+
+        if (Object.keys(payload).length === 0) {
+            showStatus(
+                "lineStatus",
+                "error",
+                "❌ Please modify at least one field",
+            );
+            return;
+        }
+
+        showLoader(true);
+
+        try {
+            const response = await fetch(
+                `${apiConfig.apiUrl}/${orderId}/${currentLineType}/${lineId}`,
+                {
+                    method: "PATCH",
+                    headers: {
+                        "Content-Type": "application/merge-patch+json",
+                        Accept: "application/json",
+                        Authorization: `Bearer ${apiConfig.apiToken}`,
+                    },
+                    body: JSON.stringify(payload),
+                },
+            );
+
+            showLoader(false);
+
+            const responseData = await response.json();
+
+            if (!response.ok) {
+                throw new Error(
+                    `HTTP ${response.status}: ${responseData.message || response.statusText}`,
+                );
+            }
+
+            showStatus(
+                "lineStatus",
+                "success",
+                "✅ Order line updated successfully!",
+            );
+            displayResponse(responseData);
+
+            // Refresh the lines
+            await fetchOrderLines();
+        } catch (error) {
+            showLoader(false);
+            showStatus(
+                "lineStatus",
+                "error",
+                `❌ Error: ${error.message}`,
+            );
+        }
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
- New workflow `claude-pr-test.yml` runs on PRs labeled `test`: boots the Order app on :8080, runs the `test-review` skill via Playwright MCP, uploads screenshots + a session.webm to the `ci-screenshots` orphan branch, and posts a PR comment.
- Companion `claude-pr-test-cleanup.yml` strips `pr-<N>/` from `ci-screenshots` when the PR closes.
- Composite action `setup-app-server` installs `src/Order` deps and starts the app in the background with a health-check loop.
- New skill `.claude/skills/test-review/SKILL.md` is diff-driven: maps changed public/*.html files to routes, takes ordered screenshots, and writes /tmp/test-review-report.md.
- `src/Order/index.js` now honors PORT env var (default 3000) so the composite action can bind to :8080 in CI without source patching.
- Adds the new Update Order page (UPDATE_ORDER_README.md + public/update-order.html) so the PR carries a meaningful diff for the skill to review.