### PR TITLE
ci: use ubuntu-latest for claude-pr-test

### DIFF
--- a/.github/workflows/claude-pr-test.yml
+++ b/.github/workflows/claude-pr-test.yml
@@ -28,7 +28,7 @@ jobs:
         (github.event.action == 'labeled' && github.event.label.name == 'test')
         || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'test'))
       )
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
       contents: write


### PR DESCRIPTION
Drops the org-only ubuntu-latest-m label so the job is always picked up on the default-tier runner pool. Fastify + Playwright Chromium fit in a 4-CPU runner with room to spare.