### PR TITLE
ci: enable full claude-code-action output for diagnosis

### DIFF
--- a/.github/workflows/claude-pr-test.yml
+++ b/.github/workflows/claude-pr-test.yml
@@ -145,7 +145,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: /tmp/claude-settings.json
-          claude_args: --mcp-config /tmp/mcp-playwright.json
+          claude_args: --mcp-config /tmp/mcp-playwright.json --debug
+          show_full_output: true
           prompt: |
             You are running a QA review of a PR in CI. Execute this exact
             sequence (the recording tools must be called by YOU at the top


### PR DESCRIPTION
The previous run reported permission_denials_count=11 but the SDK output was hidden. Enable show_full_output and pass --debug through claude_args so the next run shows which specific tool calls were denied and whether the playwright MCP server registered at all.